### PR TITLE
fix entry_type

### DIFF
--- a/custom_components/naver_weather/nweather_device.py
+++ b/custom_components/naver_weather/nweather_device.py
@@ -90,3 +90,9 @@ class NWeatherDevice(NWeatherBase, Entity):
     def should_poll(self) -> bool:
         """No polling needed for this device."""
         return False
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        attr = {}
+        return attr

--- a/custom_components/naver_weather/nweather_device.py
+++ b/custom_components/naver_weather/nweather_device.py
@@ -92,7 +92,7 @@ class NWeatherDevice(NWeatherBase, Entity):
         return False
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes (self):
         """Return the state attributes of the sensor."""
         attr = {}
         return attr

--- a/custom_components/naver_weather/nweather_device.py
+++ b/custom_components/naver_weather/nweather_device.py
@@ -90,9 +90,3 @@ class NWeatherDevice(NWeatherBase, Entity):
     def should_poll(self) -> bool:
         """No polling needed for this device."""
         return False
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes of the sensor."""
-        attr = {}
-        return attr

--- a/custom_components/naver_weather/nweather_device.py
+++ b/custom_components/naver_weather/nweather_device.py
@@ -43,7 +43,7 @@ class NWeatherBase:
             "name": f"{self.api.brand_name} {self.area}",
             "sw_version": self.api.version,
             "via_device": (DOMAIN, self.area),
-            "entry_type": "service",
+            "DeviceEntryType": "service",
         }
 
 


### PR DESCRIPTION
fix error log.
Detected code that uses str for device registry entry_type. This is deprecated and will stop working in Home Assistant 2022.3, it should be updated to use DeviceEntryType instead. Please report this issue.
