### PR TITLE
오늘비시작시간 및 오늘내일비시작시간에 "소나기" 적용

### DIFF
--- a/custom_components/naver_weather/api_nweather.py
+++ b/custom_components/naver_weather/api_nweather.py
@@ -372,11 +372,13 @@ class NWeatherAPI:
                         wt = h.select_one("i.wt_icon").text
                         tm = h.select_one("dt.time").text
 
-                        if "비" in wt and hourly_today:
+                        # 비가 오는 예보 혹은 소나기 예보 시 최초 값을 금일 비오는 날짜 설정
+                        if ("비" in wt or "소나기" in wt) and hourly_today:
                             hourly_today = False
                             rainyStart = tm
 
-                        if "비" in wt and hourly_tmr:
+                        # 비가 오는 예보 혹은 소나기 예보 시 최초값을 오늘내일 비 오는 날짜 설정
+                        if ("비" in wt or "소나기" in wt) and hourly_tmr:
                             hourly_tmr = False
                             rainyStartTmr = "내일 {}".format(tm)
                     except Exception as exx:


### PR DESCRIPTION
변경내용
- 기존
1. 오늘비시작시간에 현재시각 이후 당일까지 가장 빠른 시각으로 "비" 항목이 발견되면 적용
2. 오늘내일비시작시간에 현재시각 이후 다음날까지 가장 빠른 시각으로 "비" 항목이 발견되면 적용
- 변경
1. 오늘비시작시간에 현재시각 이후 당일까지 가장 빠른 시각으로 "비" 또는 "소나기" 항목이 발견되면 적용
2. 오늘내일비시작시간에 현재시각 이후 다음날까지 가장 빠른 시각으로 "비" 또는 "소나기" 항목이 발견되면 적용

변경 사유
: 소나기 항목도 "비"의 한 항목으로 봐야 하기에 "비"와 동일한 레벨로 적용