### PR TITLE
자외선 센서 추가

### DIFF
--- a/custom_components/naver_weather/const.py
+++ b/custom_components/naver_weather/const.py
@@ -22,8 +22,9 @@ DEVICE_UPDATE = "update"
 DEVICE_REG = "register"
 DEVICE_UNREG = "unregister"
 
-SW_VERSION = "2.2.2"
+SW_VERSION = "2.2.3"
 BSE_URL = "https://search.naver.com/search.naver?query={}"
+BSE_URL_MOBILE = "https://m.search.naver.com/search.naver?query={}"
 
 # area
 CONF_AREA = "area"
@@ -198,8 +199,8 @@ WEATHER_INFO = {
     WIND_SPEED[0]: WIND_SPEED,
     WIND_DIR[0]: WIND_DIR,
     RAINFALL[0]: RAINFALL,
-#    UV[0]: UV,
-#    UV_GRADE[0]: UV_GRADE,
+    UV[0]: UV,
+    UV_GRADE[0]: UV_GRADE,
     UDUST[0]: UDUST,
     NDUST[0]: NDUST,
     UDUST_GRADE[0]: UDUST_GRADE,

--- a/custom_components/naver_weather/manifest.json
+++ b/custom_components/naver_weather/manifest.json
@@ -6,6 +6,6 @@
   "requirements": ["beautifulsoup4==4.9.3"],
   "dependencies": [],
   "codeowners": ["@miumida", "@gugu927"],
-  "version": "2.2.2",
+  "version": "2.2.3",
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
변경사항
- 기존
1. 자외선 센서 미존재
2. 자외선 센서 점수 미존재

- 변경
1. 자외선 센서 적용
2. 자외선 센서 점수 적용

적용 방법
- 네이버 모바일 페이지 검색어로 {지역 + 자외선} 페이지 다운로드 후 해당 지역의 자외선 항목 적재
- 네이버 PC 페이지에서는 {지역 + 자외선} 검색어를 사용하여 검색하더라도 해당 지역의 자외선 정보가 나오지 않으므로 모바일 페이지를 활용함.